### PR TITLE
fix hex pattern

### DIFF
--- a/ph-css/src/main/java/com/helger/css/utils/CSSColorHelper.java
+++ b/ph-css/src/main/java/com/helger/css/utils/CSSColorHelper.java
@@ -114,7 +114,7 @@ public final class CSSColorHelper
                                              PATTERN_PART_OPACITY +
                                              "\\s*\\)$";
   @RegEx
-  private static final String PATTERN_HEX = "^" + CCSSValue.PREFIX_HEX + "[0-9a-fA-F]{1,6}$";
+  private static final String PATTERN_HEX = "^" + CCSSValue.PREFIX_HEX + "([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$";
 
   @PresentForCodeCoverage
   private static final CSSColorHelper s_aInstance = new CSSColorHelper ();


### PR DESCRIPTION
Strings starting with # and followed by 1, 2, 4 or 5 chars are not valid hex colors.