### PR TITLE
Add support for @footnote area in @page

### DIFF
--- a/ph-css/src/main/jjtree/ParserCSS30.jjt
+++ b/ph-css/src/main/jjtree/ParserCSS30.jjt
@@ -230,6 +230,7 @@ TOKEN :
 | < RIGHTTOP_SYM:           "@right-top" >
 | < RIGHTMIDDLE_SYM:        "@right-middle" >
 | < RIGHTBOTTOM_SYM:        "@right-bottom" >
+| < FOOTNOTE_SYM:           "@footnote" >
 | < MEDIA_SYM: "@media" >
 | < FONTFACE_SYM: "@-" <IDENT> "-font-face"
                 | "@font-face" >
@@ -1322,6 +1323,7 @@ void pageMarginSymbol() : {}
   | <RIGHTTOP_SYM>          { jjtThis.setText (token.image); }
   | <RIGHTMIDDLE_SYM>       { jjtThis.setText (token.image); }
   | <RIGHTBOTTOM_SYM>       { jjtThis.setText (token.image); }
+  | <FOOTNOTE_SYM>          { jjtThis.setText (token.image); }
   )
 }
 
@@ -1557,6 +1559,7 @@ void unknownRule() : {}
   | <RIGHTTOP_SYM>          { jjtThis.setText (token.image); }
   | <RIGHTMIDDLE_SYM>       { jjtThis.setText (token.image); }
   | <RIGHTBOTTOM_SYM>       { jjtThis.setText (token.image); }
+  | <FOOTNOTE_SYM>          { jjtThis.setText (token.image); }
   )
   unknownRuleParameterList()
   unknownRuleBody()

--- a/ph-css/src/test/java/com/helger/css/reader/CSSReader30SpecialFuncTest.java
+++ b/ph-css/src/test/java/com/helger/css/reader/CSSReader30SpecialFuncTest.java
@@ -37,6 +37,8 @@ import com.helger.css.decl.CSSExpressionMemberFunction;
 import com.helger.css.decl.CSSExpressionMemberMath;
 import com.helger.css.decl.CSSExpressionMemberTermSimple;
 import com.helger.css.decl.CSSExpressionMemberTermURI;
+import com.helger.css.decl.CSSPageMarginBlock;
+import com.helger.css.decl.CSSPageRule;
 import com.helger.css.decl.CSSStyleRule;
 import com.helger.css.decl.CascadingStyleSheet;
 import com.helger.css.decl.ICSSExpressionMember;
@@ -353,5 +355,26 @@ public final class CSSReader30SpecialFuncTest
     assertEquals (2, aCSS.getStyleRuleAtIndex (10).getDeclarationCount ());
     assertEquals (2, aCSS.getStyleRuleAtIndex (11).getDeclarationCount ());
     assertEquals (1, aCSS.getStyleRuleAtIndex (12).getDeclarationCount ());
+  }
+
+
+  @Test
+  public void testReadFootnote ()
+  {
+    final ECSSVersion eVersion = ECSSVersion.CSS30;
+    final Charset aCharset = StandardCharsets.UTF_8;
+    final File aFile = new File ("src/test/resources/testfiles/css30/good/artificial/test-footnotes.css");
+    final CascadingStyleSheet aCSS = CSSReader.readFromFile (aFile, aCharset, eVersion);
+    assertNotNull (aCSS);
+    assertEquals (5, aCSS.getRuleCount ());
+    assertEquals (3, aCSS.getStyleRuleCount ());
+
+    // @page { @footnote { border-top: ..} }
+    assertTrue ( aCSS.getRuleAtIndex(1) instanceof CSSPageRule);
+    assertEquals ( 1, ((CSSPageRule) aCSS.getRuleAtIndex(1)).getMemberCount());
+    assertTrue ( ((CSSPageRule) aCSS.getRuleAtIndex(1)).getMemberAtIndex(0) instanceof CSSPageMarginBlock);
+    final CSSPageMarginBlock footnoteBlock = (CSSPageMarginBlock) ((CSSPageRule) aCSS.getRuleAtIndex(1)).getMemberAtIndex(0);
+    assertEquals ("@footnote", footnoteBlock.getPageMarginSymbol());
+    assertEquals ( 1, footnoteBlock.getDeclarationCount());
   }
 }

--- a/ph-css/src/test/resources/testfiles/css30/good/artificial/test-footnotes.css
+++ b/ph-css/src/test/resources/testfiles/css30/good/artificial/test-footnotes.css
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2021 Daniel Schmidt
+ * daniel[at]ad-schmidt[dot]de
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+ Styling the @footnote area is part of the CSS Generated Content for Paged Media Module.
+ Current W3C Working Draft: https://www.w3.org/TR/css-gcpm-3/
+ */
+@page {
+    counter-reset: footnoteCounter 0;
+}
+@page {
+    @footnote {
+        border-top: dotted green 0.5pt;
+    }
+}
+
+.footnote {
+    float: footnote;
+    counter-increment: footnoteCounter;
+}
+
+::footnote-call {
+    content: counter(footnoteCounter, decimal) ")";
+    vertical-align: super;
+    font-size: 70%;
+}
+::footnote-marker {
+     content: counter(footnoteCounter, decimal) ")";
+ }


### PR DESCRIPTION
Hi, 
we use ph-css as part of a product that uses CSS for generating print layouts. In this use case we also need to support footnotes as defined in this w3c working draft: https://www.w3.org/TR/css-gcpm-3/

However parsing CSS files that use this kind of structure, failed with ph-css:
```
@page {
  @footnote {
    float: bottom;
  }
}
```
In the grammar I added @footnote just like the other page margins even if it not a margin per se but a page area. From a CSS point of view however I think this is fine, as it does behave like a page margin.

I also added a test css file and a test, that the file is read correctly. Is test css file read by the general tests as well or is there another place to register this test file?

The other extensions from this working draft (`::footnote-call ` and `::footnote-marker`) should already work I assume. Do you see any problems with them?