### PR TITLE
Correctly expand CSS `border-width` property

### DIFF
--- a/ph-css/src/main/java/com/helger/css/decl/shorthand/CSSShortHandRegistry.java
+++ b/ph-css/src/main/java/com/helger/css/decl/shorthand/CSSShortHandRegistry.java
@@ -110,7 +110,7 @@ public final class CSSShortHandRegistry
                                                                                               CCSSValue.SOLID),
                                                              new CSSPropertyWithDefaultValue (CCSSProperties.BORDER_LEFT_COLOR,
                                                                                               ECSSColor.BLACK.getName ())));
-    registerShortHandDescriptor (new CSSShortHandDescriptor (ECSSProperty.BORDER_WIDTH,
+    registerShortHandDescriptor (new CSSShortHandDescriptorWithAlignment (ECSSProperty.BORDER_WIDTH,
                                                              new CSSPropertyWithDefaultValue (CCSSProperties.BORDER_TOP_WIDTH,
                                                                                               ECSSUnit.px (3)),
                                                              new CSSPropertyWithDefaultValue (CCSSProperties.BORDER_RIGHT_WIDTH,


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/CSS/border-width should support 2 value and 3 value variants and right now it doesn't.